### PR TITLE
fix: handling innerRef

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -80,7 +80,13 @@ class Link extends Component {
 
     if (router) {
       if (withRef) {
-        props.ref = (c) => withRef(c)
+        props.ref = (c) => {
+          if (typeof innerRef === 'function') {
+            innerRef(c)
+          }
+
+          return withRef(c)
+        }
       }
 
       // If user does not specify a `to` prop, return an empty anchor tag.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintoandar/react-router",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "React Router v3 compatible with concurrent mode",
   "files": [
     "*.md",


### PR DESCRIPTION
## WHAT AND WHY

This PR fixes `Link` component ref when prop `to` is provided. `innerRef` prop was not being handled properly, so it couldn't be used.